### PR TITLE
Show validation errors functions for multiselect and select editors

### DIFF
--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -111,6 +111,7 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
   },
   postBuild: function() {
       this._super();
+      this.theme.afterInputReady(this.input);
       this.setupSelect2();
   },
   register: function() {
@@ -193,5 +194,28 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
         this.select2 = null;
     }
     this._super();
+  },
+  showValidationErrors: function(errors) {
+    var self = this;
+
+    if(this.jsoneditor.options.show_errors === "always") {}
+    else if(!this.is_dirty && this.previous_error_setting===this.jsoneditor.options.show_errors) return;
+
+    this.previous_error_setting = this.jsoneditor.options.show_errors;
+
+    var messages = [];
+    $each(errors, function(i,error) {
+      if(error.path === self.path) {
+        messages.push(error.message);
+      }
+    });
+
+    if(messages.length) {
+      this.theme.addInputError(this.input, messages.join('. ') + '.');
+    }
+    else {
+      this.theme.removeInputError(this.input);
+    }
+
   }
 });

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -350,5 +350,22 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
     }
 
     this._super();
+  },
+  showValidationErrors: function(errors) {
+    var self = this;
+
+    var messages = [];
+    $each(errors, function(i,error) {
+      if(error.path === self.path) {
+        messages.push(error.message);
+      }
+    });
+
+    if(messages.length) {
+      this.theme.addInputError(this.input, messages.join('. ') + '.');
+    }
+    else {
+      this.theme.removeInputError(this.input);
+    }
   }
 });


### PR DESCRIPTION
> - this.input is not always defined for the multiselect editor. If there are only a few options, it uses multiple checkboxes instead and uses a this.inputs object. The code should handle both cases.
> - Remove lines 201 and 202 in multiselect. That code will only work for the string editor where you copied it from. The multiselect editor doesn't set this.is_dirty anywhere.