### PR TITLE
Bug fix: supplying startval with a value of `false`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -59,7 +59,7 @@ JSONEditor.prototype = {
       self.root.postBuild();
 
       // Starting data
-      if(self.options.startval) self.root.setValue(self.options.startval);
+      if(self.options.hasOwnProperty('startval')) self.root.setValue(self.options.startval);
 
       self.validation_results = self.validator.validate(self.root.getValue());
       self.root.showValidationErrors(self.validation_results);


### PR DESCRIPTION
> his fixes an issue I saw, when I set startval to false (with no schema) the form does not render a boolean, instead it renders null.
> 
> The bug is demonstrated in this jsfiddle: https://jsfiddle.net/joelnordell/rx60sy2L/
> The fix is demonstrated in this jsfiddle: https://jsfiddle.net/joelnordell/z8pjLsju/